### PR TITLE
add `nerds/factors.rs` and `mathfmt` filter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -285,9 +285,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.12"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5"
+checksum = "a06fddc2749e0528d2813f95e050e87e52c8cbbae56223b9babf73b3e53b0cc6"
 dependencies = [
  "cfg-if",
  "libc",
@@ -512,6 +512,7 @@ version = "0.1.0"
 dependencies = [
  "askama",
  "askama_axum",
+ "askama_escape",
  "axum",
  "proptest",
  "rug",
@@ -724,9 +725,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.3"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
+checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "rug"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 [dependencies]
 askama = { version = "0.12", features = ["with-axum"] }
 askama_axum = "0.4"
+askama_escape = "0.10.3"
 axum = "0.7"
 rug = { version = "1.24", default-features = false, features = ["integer"] }
 tokio = { version = "1", features = ["full"] }

--- a/src/filters.rs
+++ b/src/filters.rs
@@ -1,0 +1,69 @@
+use std::{iter::Peekable, str::Chars};
+
+type StrCursor<'a> = Peekable<Chars<'a>>;
+
+fn parse_balanced_parens(s: &mut StrCursor, out: &mut String) {
+    let mut brack_count = 0u32;
+    while let Some(c) = s.next() {
+        match c {
+            '(' => {
+                brack_count += 1;
+                out.push(c);
+            },
+            ')' => {
+                if brack_count == 0 {
+                    return;
+                }
+                brack_count -= 1;
+                out.push(c);
+            }
+            '\\' => match s.next() {
+                None => {
+                    out.push('\\');
+                    return;
+                }
+                Some(d) => out.push(d),
+            },
+            '^' if s.peek() == Some(&'(') => {
+                s.next();
+                out.push_str("<sup>");
+                parse_balanced_parens(s, out);
+                out.push_str("</sup>");
+            }
+            _ => out.push(c),
+        }
+    }
+}
+
+fn parse(s: &mut StrCursor) -> String {
+    let mut res = String::new();
+    while s.peek().is_some() {
+        parse_balanced_parens(s, &mut res);
+    }
+    res
+}
+
+pub fn mathfmt<T: std::fmt::Display>(s: T) -> askama::Result<String> {
+    let s = askama::filters::escape(askama_escape::Html, s)?.to_string();
+    Ok(parse(&mut s.chars().peekable()))
+}
+
+#[test]
+fn mathfmt_test() {
+    macro_rules! check {
+        ($a:expr, $b:expr) => {
+            assert_eq!(mathfmt($a).unwrap(), $b)
+        };
+    }
+    check!(
+        "<html>gets escaped</html>",
+        "&lt;html&gt;gets escaped&lt;/html&gt;"
+    );
+    check!("super^(script)", "super<sup>script</sup>");
+    check!("parens^(bal(an)ce)", "parens<sup>bal(an)ce</sup>");
+    check!("unclosed^(is()ignored", "unclosed<sup>is()ignored</sup>");
+    check!("not\\^(superscript)", "not^(superscript)");
+    check!("backslash escapes \\anything", "backslash escapes anything");
+    check!("single\\\\backslash", "single\\backslash");
+    check!("no parens means ^ verbatim", "no parens means ^ verbatim");
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ use axum::{extract::Path, http::StatusCode, routing::get, Router};
 use rug::Integer;
 use tokio::task::JoinSet;
 
+mod filters;
 mod nerds;
 
 #[tokio::main]
@@ -53,7 +54,9 @@ async fn handle_int<'a>(Path(param): Path<String>) -> Result<IntTemplate, (Statu
         }
     }
 
-    let info = tokio::fs::read_to_string(format!("templates/{n}.html")).await.ok();
+    let info = tokio::fs::read_to_string(format!("templates/{n}.html"))
+        .await
+        .ok();
 
     Ok(IntTemplate { n, info, facts })
 }

--- a/src/nerds/factors.rs
+++ b/src/nerds/factors.rs
@@ -1,0 +1,138 @@
+use std::sync::Arc;
+
+use rug::Integer;
+
+const LIMIT: u32 = 100_000_000;
+
+/// Expects 2 <= n <= LIMIT.
+fn factors_impl(mut n: u32) -> Vec<(u32, u32)> {
+    let mut factors = Vec::new();
+    let mut two_count = 0;
+    while n % 2 == 0 {
+        n /= 2;
+        two_count += 1;
+    }
+    if two_count != 0 {
+        factors.push((2, two_count));
+    }
+
+    // Note: `factors` will only contain prime numbers.
+    // This is because no composite factor of the number
+    // can be encountered before the factors of that composite factor.
+    let mut i = 3;
+    while n != 1 && i * i <= n {
+        let mut count = 0;
+        while n % i == 0 {
+            n /= i;
+            count += 1;
+        }
+        if count != 0 {
+            factors.push((i, count));
+        }
+        i += 2;
+    }
+    // The remainder must be a prime number.
+    if n != 1 {
+        factors.push((n, 1));
+    }
+    factors
+}
+
+pub fn factors(n: Arc<Integer>) -> Option<String> {
+    let n = n.to_u32()?;
+    if n <= 1 || n > LIMIT {
+        return None;
+    }
+    let factors = factors_impl(n);
+    if factors.is_empty() {
+        return None;
+    }
+    let factors_text: Vec<_> = factors
+        .into_iter()
+        .map(|(k, count)| {
+            if count == 1 {
+                format!("{k}")
+            } else {
+                format!("{k}^({count})")
+            }
+        })
+        .collect();
+    let formatted = factors_text.join("×");
+    Some(format!("The prime factors of this number are {formatted}."))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use proptest::prelude::*;
+
+    #[test]
+    fn factors_format_properly() {
+        macro_rules! check {
+            ($a:expr, $b:expr) => {
+                assert_eq!(
+                    factors(Arc::new(Integer::from($a))),
+                    Some(concat!("The prime factors of this number are ", $b, ".").to_owned())
+                )
+            };
+        }
+        check!(19, "19");
+        check!(198900, "2^(2)×3^(2)×5^(2)×13×17");
+    }
+
+    proptest! {
+        #[test]
+        fn factors_multiply_to_num(n in 2..100_000_000u32) {
+            let factors = factors_impl(n);
+            let multiplied: u32 = factors.into_iter().map(|(p, count)| p.pow(count)).product();
+            prop_assert_eq!(n, multiplied);
+        }
+
+        #[test]
+        fn only_prime_factors(n in 2..100_000_000u32) {
+            let factors = factors_impl(n);
+            for (p, _) in factors.iter() {
+                let p_factors = factors_impl(*p);
+                prop_assert!(p_factors == vec![(*p, 1)], "factor {p} was not a prime number: {:?}", p_factors);
+            }
+        }
+
+        #[test]
+        fn factors_distribute_over_mul(a in 2..10_000u32, b in 2..10_000u32) {
+            let fa = factors_impl(a);
+            let fb = factors_impl(b);
+            let fab = factors_impl(a*b);
+            let mut merged = Vec::new();
+            let mut i = 0;
+            let mut j = 0;
+            loop {
+                match (fa.get(i), fb.get(j)) {
+                    (Some(&(x, cx)), Some(&(y, cy))) => {
+                        if x == y {
+                            merged.push((x, cx+cy));
+                            i += 1;
+                            j += 1;
+                        } else if x < y {
+                            merged.push((x, cx));
+                            i += 1;
+                        } else {
+                            merged.push((y, cy));
+                            j += 1;
+                        }
+                    },
+                    (Some(t), None) => {
+                        merged.push(*t);
+                        i += 1;
+                    },
+                    (None, Some(t)) => {
+                        merged.push(*t);
+                        j += 1;
+                    }
+                    (None, None) => break,
+                }
+            }
+            prop_assert_eq!(fab, merged);
+        }
+    }
+}

--- a/src/nerds/mod.rs
+++ b/src/nerds/mod.rs
@@ -2,9 +2,14 @@ use std::sync::Arc;
 
 use rug::Integer;
 
+mod factors;
 mod parity;
 mod prime;
 mod triangular;
 
-pub const NERDS: &[fn(Arc<Integer>) -> Option<String>] =
-    &[parity::parity, triangular::triangular, prime::prime];
+pub const NERDS: &[fn(Arc<Integer>) -> Option<String>] = &[
+    parity::parity,
+    triangular::triangular,
+    prime::prime,
+    factors::factors,
+];

--- a/templates/int.html
+++ b/templates/int.html
@@ -17,7 +17,7 @@
     <div class="auto">
         <ul>
             {% for fact in facts %}
-            <li>{{ fact }}</li>
+            <li>{{ fact|mathfmt|safe }}</li>
             {% endfor %}
         </ul>
     </div>


### PR DESCRIPTION
`nerds/factors.rs`: Displays the prime factors of the number (2 <= N <= 10^8).

The`mathfmt` filter changes `x^(y)` to `x<sup>y</sup>`. (This is all it does currently; it can be extended to support more custom formatting. You can print `^` verbatim by typing `\^`.)