### PR TITLE
feat(mathfmt): numeric hyperlinks

### DIFF
--- a/src/filters.rs
+++ b/src/filters.rs
@@ -2,50 +2,137 @@ use std::{iter::Peekable, str::Chars};
 
 type StrCursor<'a> = Peekable<Chars<'a>>;
 
-fn parse_balanced_parens(s: &mut StrCursor, out: &mut String) {
-    let mut brack_count = 0u32;
-    while let Some(c) = s.next() {
+struct HtmlEmitter {
+    out: String,
+}
+
+impl HtmlEmitter {
+    /// Use in contexts where text is expected (anything except the interior attribute
+    /// section of a tag or closing tag.)
+    fn emit_text_char(&mut self, c: char) {
         match c {
-            '(' => {
-                brack_count += 1;
-                out.push(c);
-            },
+            '&' => self.out.push_str("&amp;"),
+            '<' => self.out.push_str("&lt;"),
+            '>' => self.out.push_str("&gt;"),
+            '"' => self.out.push_str("&quot;"),
+            '\'' => self.out.push_str("&#39;"),
+            _ => self.out.push(c),
+        }
+    }
+
+    fn emit_text_str(&mut self, s: &str) {
+        for c in s.chars() {
+            self.emit_text_char(c);
+        }
+    }
+
+    /// Lifetime is 'static to ensure that no user input is snuck into this function.
+    fn emit_raw_str(&mut self, s: &'static str) {
+        self.out.push_str(s);
+    }
+
+    /// Escapes a link.
+    /// Does *not* sanitize against `javascript:` URIs.
+    fn emit_link(&mut self, link: &str, link_text: &str) {
+        self.emit_raw_str("<a href=\"");
+        // Note: This can't panic because askama's urlencode implementation always returns Ok.
+        self.out
+            .push_str(&askama::filters::urlencode(link).unwrap());
+        self.emit_raw_str("\">");
+        self.emit_text_str(link_text);
+        self.emit_raw_str("</a>");
+    }
+}
+
+fn superscript_handler(s: &mut StrCursor, out: &mut HtmlEmitter) {
+    s.next();
+    out.emit_raw_str("<sup>");
+    parse_balanced_parens(s, out);
+    // eat closing paren
+    s.next();
+    out.emit_raw_str("</sup>");
+}
+
+fn num_link_handler(s: &mut StrCursor, out: &mut HtmlEmitter) {
+    s.next();
+    let mut num = String::with_capacity(16);
+    for c in s.by_ref() {
+        match c {
+            '0'..='9' => {
+                num.push(c);
+            }
             ')' => {
-                if brack_count == 0 {
-                    return;
-                }
-                brack_count -= 1;
-                out.push(c);
+                out.emit_link(&format!("/{num}"), &num);
+                return;
             }
-            '\\' => match s.next() {
-                None => {
-                    out.push('\\');
-                    return;
-                }
-                Some(d) => out.push(d),
-            },
-            '^' if s.peek() == Some(&'(') => {
-                s.next();
-                out.push_str("<sup>");
-                parse_balanced_parens(s, out);
-                out.push_str("</sup>");
+            _ => {
+                // fallback if not given a number, pretend this wasn't handled at all
+                out.emit_text_str(&format!("(#{num}"));
+                out.emit_text_char(c);
+                return;
             }
-            _ => out.push(c),
         }
     }
 }
 
-fn parse(s: &mut StrCursor) -> String {
-    let mut res = String::new();
-    while s.peek().is_some() {
-        parse_balanced_parens(s, &mut res);
+fn parse_balanced_parens(s: &mut StrCursor, out: &mut HtmlEmitter) {
+    let mut brack_count = 0u32;
+    while let Some(&c) = s.peek() {
+        match c {
+            '(' => {
+                s.next();
+                match s.peek() {
+                    Some(&'^') => superscript_handler(s, out),
+                    Some(&'#') => num_link_handler(s, out),
+                    _ => {
+                        brack_count += 1;
+                        out.emit_text_char(c);
+                    }
+                }
+            }
+            ')' => {
+                if brack_count == 0 {
+                    return;
+                }
+                s.next();
+                brack_count -= 1;
+                out.emit_text_char(c);
+            }
+            '\\' => {
+                s.next();
+                match s.next() {
+                    None => {
+                        out.emit_text_char('\\');
+                        return;
+                    }
+                    Some(d) => out.emit_text_char(d),
+                }
+            }
+            _ => {
+                s.next();
+                out.emit_text_char(c);
+            }
+        }
     }
-    res
+}
+
+fn run_filter(s: &mut StrCursor) -> String {
+    let mut res = HtmlEmitter { out: String::new() };
+    loop {
+        match s.peek() {
+            Some(')') => {
+                res.emit_text_char(')');
+                s.next();
+            }
+            Some(_) => parse_balanced_parens(s, &mut res),
+            None => break,
+        }
+    }
+    res.out
 }
 
 pub fn mathfmt<T: std::fmt::Display>(s: T) -> askama::Result<String> {
-    let s = askama::filters::escape(askama_escape::Html, s)?.to_string();
-    Ok(parse(&mut s.chars().peekable()))
+    Ok(run_filter(&mut s.to_string().chars().peekable()))
 }
 
 #[test]
@@ -56,14 +143,35 @@ fn mathfmt_test() {
         };
     }
     check!(
-        "<html>gets escaped</html>",
-        "&lt;html&gt;gets escaped&lt;/html&gt;"
+        r#"<html>&gets' "escaped"</html>"#,
+        "&lt;html&gt;&amp;gets&#39; &quot;escaped&quot;&lt;/html&gt;"
     );
-    check!("super^(script)", "super<sup>script</sup>");
-    check!("parens^(bal(an)ce)", "parens<sup>bal(an)ce</sup>");
-    check!("unclosed^(is()ignored", "unclosed<sup>is()ignored</sup>");
-    check!("not\\^(superscript)", "not^(superscript)");
+    check!("super(^script)", "super<sup>script</sup>");
+    check!(
+        "super(^script) and after",
+        "super<sup>script</sup> and after"
+    );
+    check!("parens(^bal(an)ce)", "parens<sup>bal(an)ce</sup>");
+    check!("unclosed(^is()ignored", "unclosed<sup>is()ignored</sup>");
+    check!("not(\\^superscript)", "not(^superscript)");
     check!("backslash escapes \\anything", "backslash escapes anything");
     check!("single\\\\backslash", "single\\backslash");
     check!("no parens means ^ verbatim", "no parens means ^ verbatim");
+
+    check!(
+        "links (#537) to numbers",
+        "links <a href=\"/537\">537</a> to numbers"
+    );
+
+    check!(
+        "nested(^link(#11) with text after)",
+        "nested<sup>link<a href=\"/11\">11</a> with text after</sup>"
+    );
+
+    check!(
+        "nested(^link(#11))",
+        "nested<sup>link<a href=\"/11\">11</a></sup>"
+    );
+
+    check!("links fail without parens #11", "links fail without parens #11");
 }

--- a/src/nerds/factors.rs
+++ b/src/nerds/factors.rs
@@ -51,9 +51,9 @@ pub fn factors(n: Arc<Integer>) -> Option<String> {
         .into_iter()
         .map(|(k, count)| {
             if count == 1 {
-                format!("{k}")
+                format!("(#{k})")
             } else {
-                format!("{k}^({count})")
+                format!("(#{k})(^{count})")
             }
         })
         .collect();
@@ -77,8 +77,8 @@ mod tests {
                 )
             };
         }
-        check!(19, "19");
-        check!(198900, "2^(2)×3^(2)×5^(2)×13×17");
+        check!(19, "(#19)");
+        check!(198900, "(#2)(^2)×(#3)(^2)×(#5)(^2)×(#13)×(#17)");
     }
 
     proptest! {

--- a/src/nerds/triangular.rs
+++ b/src/nerds/triangular.rs
@@ -8,7 +8,7 @@ pub fn triangular(n: Arc<Integer>) -> Option<String> {
         return None;
     }
     let root = (disc - 1) / 2;
-    Some(format!("Is the {root}th triangular number."))
+    Some(format!("Is the (#{root})th triangular number."))
 }
 
 #[cfg(test)]
@@ -25,7 +25,7 @@ mod tests {
             let x = (&nth + &nth*&nth).complete()/2;
             prop_assert_eq!(
                 triangular(Arc::new(x)),
-                Some(format!("Is the {nth}th triangular number."))
+                Some(format!("Is the (#{nth})th triangular number."))
             );
         }
     }


### PR DESCRIPTION
Uses `(#num)` to link to number `num`; e.g. `(#537)` would produce the HTML `<a href="/537">537</a>`.