### PR TITLE
tests: refactor to use common test harness

### DIFF
--- a/src/nerds/factors.rs
+++ b/src/nerds/factors.rs
@@ -71,30 +71,23 @@ mod tests {
     use super::*;
 
     use proptest::prelude::*;
-    use tokio::runtime;
 
     #[test]
     fn factors_format_properly() {
-        runtime::Builder::new_current_thread()
-            .build()
-            .unwrap()
-            .block_on(async {
-                let (tx, mut rx) = mpsc::channel(1);
-                macro_rules! check {
-                    ($a:expr, $b:expr) => {
-                        factors(Arc::new(Integer::from($a)), tx.clone()).await;
-                        assert_eq!(
-                            rx.recv().await,
-                            Some(
-                                concat!("The prime factors of this number are ", $b, ".")
-                                    .to_owned()
-                            )
-                        )
-                    };
-                }
-                check!(19, "(#19)");
-                check!(198900, "(#2)(^(#2))×(#3)(^(#2))×(#5)(^(#2))×(#13)×(#17)");
-            });
+        crate::test_harness!(|| {
+            let (tx, mut rx) = mpsc::channel(1);
+            macro_rules! check {
+                ($a:expr, $b:expr) => {
+                    factors(Arc::new(Integer::from($a)), tx.clone()).await;
+                    assert_eq!(
+                        rx.recv().await,
+                        Some(concat!("The prime factors of this number are ", $b, ".").to_owned())
+                    )
+                };
+            }
+            check!(19, "(#19)");
+            check!(198900, "(#2)(^(#2))×(#3)(^(#2))×(#5)(^(#2))×(#13)×(#17)");
+        });
     }
 
     proptest! {

--- a/src/nerds/mod.rs
+++ b/src/nerds/mod.rs
@@ -25,3 +25,25 @@ pub async fn ask_nerds(n: Arc<Integer>) -> Vec<String> {
     }
     facts
 }
+
+#[macro_export]
+macro_rules! test_harness {
+    (|| $body:block) => {
+        // don't use proptest
+        tokio::runtime::Builder::new_current_thread()
+            .build()
+            .unwrap()
+            .block_on(async move $body);
+    };
+    (|($($v:pat in $e:expr),+)| $body:block) => {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .build()
+            .unwrap();
+        proptest!(|($($v in $e),*)| {
+            rt.block_on(async move {
+                $body;
+                Ok(())
+            })?;
+        });
+    };
+}

--- a/src/nerds/parity.rs
+++ b/src/nerds/parity.rs
@@ -19,33 +19,30 @@ mod tests {
 
     use proptest::prelude::*;
     use rug::Complete;
-    use tokio::runtime;
 
-    proptest! {
-        #[test]
-        fn even(n in "[0-9]+") {
-            runtime::Builder::new_current_thread().build().unwrap().block_on(async {
-                let x = Integer::parse(n).unwrap().complete() * 2;
-                let (tx, mut rx) = mpsc::channel(1);
-                parity(Arc::new(x), tx).await;
-                assert_eq!(
-                    rx.recv().await,
-                    Some("Is an even number.".to_string())
-                )
-            });
-        }
+    #[test]
+    fn even() {
+        crate::test_harness!(|(n in "[0-9]+")| {
+            let x = Integer::parse(n).unwrap().complete() * 2;
+            let (tx, mut rx) = mpsc::channel(1);
+            parity(Arc::new(x), tx).await;
+            prop_assert_eq!(
+                rx.recv().await,
+                Some("Is an even number.".to_string())
+            )
+        });
+    }
 
-        #[test]
-        fn odd(n in "[0-9]+") {
-            runtime::Builder::new_current_thread().build().unwrap().block_on(async {
-                let x = Integer::parse(n).unwrap().complete() * 2 + 1;
-                let (tx, mut rx) = mpsc::channel(1);
-                parity(Arc::new(x), tx).await;
-                assert_eq!(
-                    rx.recv().await,
-                    Some("Is an odd number.".to_string())
-                )
-            });
-        }
+    #[test]
+    fn odd() {
+        crate::test_harness!(|(n in "[0-9]+")| {
+            let x = Integer::parse(n).unwrap().complete() * 2 + 1;
+            let (tx, mut rx) = mpsc::channel(1);
+            parity(Arc::new(x), tx).await;
+            prop_assert_eq!(
+                rx.recv().await,
+                Some("Is an odd number.".to_string())
+            )
+        });
     }
 }

--- a/src/nerds/prime.rs
+++ b/src/nerds/prime.rs
@@ -20,23 +20,20 @@ mod tests {
 
     use proptest::prelude::*;
     use rug::Complete;
-    use tokio::runtime;
 
-    proptest! {
-        #[test]
-        fn no_composites(a in "[0-9]+", b in "[0-9]+") {
-            runtime::Builder::new_current_thread().build().unwrap().block_on(async {
-                let a = Integer::parse(a).unwrap().complete() + 2;
-                let b = Integer::parse(b).unwrap().complete() + 2;
-                let x = a*b;
+    #[test]
+    fn no_composites() {
+        crate::test_harness!(|(a in "[0-9]+", b in "[0-9]+")| {
+            let a = Integer::parse(a).unwrap().complete() + 2;
+            let b = Integer::parse(b).unwrap().complete() + 2;
+            let x = a*b;
 
-                let (tx, mut rx) = mpsc::channel(1);
-                prime(Arc::new(x), tx).await;
-                assert_eq!(
-                    rx.recv().await,
-                    None
-                );
-            });
-        }
+            let (tx, mut rx) = mpsc::channel(1);
+            prime(Arc::new(x), tx).await;
+            prop_assert_eq!(
+                rx.recv().await,
+                None
+            );
+        });
     }
 }

--- a/src/nerds/triangular.rs
+++ b/src/nerds/triangular.rs
@@ -17,25 +17,23 @@ pub async fn triangular(n: Arc<Integer>, tx: mpsc::Sender<String>) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_harness;
 
     use proptest::prelude::*;
     use rug::Complete;
-    use tokio::runtime;
 
-    proptest! {
-        #[test]
-        fn positive_match(n in "[0-9]+") {
-            runtime::Builder::new_current_thread().build().unwrap().block_on(async {
-                let nth = Integer::parse(n).unwrap().complete();
-                let x = (&nth + &nth*&nth).complete()/2;
+    #[test]
+    fn positive_match() {
+        test_harness!(|(n in "[0-9]+")| {
+            let nth = Integer::parse(n).unwrap().complete();
+            let x = (&nth + &nth*&nth).complete()/2;
 
-                let (tx, mut rx) = mpsc::channel(1);
-                triangular(Arc::new(x), tx).await;
-                assert_eq!(
-                    rx.recv().await,
-                    Some(format!("Is the (#{nth})th triangular number."))
-                );
-            });
-        }
+            let (tx, mut rx) = mpsc::channel(1);
+            triangular(Arc::new(x), tx).await;
+            prop_assert_eq!(
+                rx.recv().await,
+                Some(format!("Is the (#{nth})th triangular number."))
+            );
+        });
     }
 }


### PR DESCRIPTION
Usage:

```rust
test_harness!(|| {
  /* regular async test */
})

test_harness!(|(n in "[0-9]"+)| {
  /* proptest async test */
})
```