### PR TITLE
feat: add fact types

### DIFF
--- a/src/filters.rs
+++ b/src/filters.rs
@@ -173,5 +173,8 @@ fn mathfmt_test() {
         "nested<sup>link<a href=\"/11\">11</a></sup>"
     );
 
-    check!("links fail without parens #11", "links fail without parens #11");
+    check!(
+        "links fail without parens #11",
+        "links fail without parens #11"
+    );
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,8 +22,8 @@ async fn main() {
 #[template(path = "int.html")]
 struct IntTemplate {
     n: Arc<Integer>,
-    info: Option<String>,
-    facts: Vec<String>,
+    manual: Option<String>,
+    info: nerds::NumberInfo,
 }
 
 async fn handle_int(Path(param): Path<String>) -> Result<IntTemplate, (StatusCode, String)> {
@@ -42,13 +42,13 @@ async fn handle_int(Path(param): Path<String>) -> Result<IntTemplate, (StatusCod
 
     let n = Arc::new(n);
 
-    let get_info = tokio::fs::read_to_string(format!("templates/{n}.html"));
-    let (info, facts) = tokio::join!(get_info, nerds::ask_nerds(n.clone()));
+    let get_manual = tokio::fs::read_to_string(format!("templates/{n}.html"));
+    let (manual, facts) = tokio::join!(get_manual, nerds::ask_nerds(n.clone()));
 
     Ok(IntTemplate {
         n,
-        info: info.ok(),
-        facts,
+        manual: manual.ok(),
+        info: facts,
     })
 }
 

--- a/src/nerds/fibonacci.rs
+++ b/src/nerds/fibonacci.rs
@@ -4,11 +4,16 @@ use phf::phf_map;
 use rug::{Assign, Complete, Integer};
 use tokio::sync::mpsc;
 
-pub async fn fibonacci(n: Arc<Integer>, tx: mpsc::Sender<String>) {
+use super::Fact;
+
+pub async fn fibonacci(n: Arc<Integer>, tx: mpsc::Sender<Fact>) {
     if is_fib(&n) {
-        tx.send(format!("Is the (#{})th fibonacci number.", fib_index(&n)))
-            .await
-            .unwrap();
+        tx.send(Fact::Basic(format!(
+            "Is the (#{})th fibonacci number.",
+            fib_index(&n)
+        )))
+        .await
+        .unwrap();
     }
 }
 

--- a/src/nerds/parity.rs
+++ b/src/nerds/parity.rs
@@ -3,12 +3,14 @@ use std::sync::Arc;
 use rug::Integer;
 use tokio::sync::mpsc;
 
-pub async fn parity(n: Arc<Integer>, tx: mpsc::Sender<String>) {
-    tx.send(if n.is_even() {
+use super::Fact;
+
+pub async fn parity(n: Arc<Integer>, tx: mpsc::Sender<Fact>) {
+    tx.send(Fact::Basic(if n.is_even() {
         "Is an even number.".to_string()
     } else {
         "Is an odd number.".to_string()
-    })
+    }))
     .await
     .unwrap();
 }
@@ -28,7 +30,7 @@ mod tests {
             parity(Arc::new(x), tx).await;
             prop_assert_eq!(
                 rx.recv().await,
-                Some("Is an even number.".to_string())
+                Some(Fact::Basic("Is an even number.".to_string()))
             )
         });
     }
@@ -41,7 +43,7 @@ mod tests {
             parity(Arc::new(x), tx).await;
             prop_assert_eq!(
                 rx.recv().await,
-                Some("Is an odd number.".to_string())
+                Some(Fact::Basic("Is an odd number.".to_string()))
             )
         });
     }

--- a/src/nerds/power_form.rs
+++ b/src/nerds/power_form.rs
@@ -15,6 +15,8 @@ use num_traits::identities::One;
 use rug::{Complete, Integer};
 use tokio::sync::mpsc;
 
+use super::Fact;
+
 const SMALL_PRIMES: &[u32] = &[
     2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97,
 ];
@@ -114,14 +116,17 @@ fn power_form_impl(mut n: Integer) -> Option<(Integer, u32)> {
     }
 }
 
-pub async fn power_form(n: Arc<Integer>, tx: mpsc::Sender<String>) {
+pub async fn power_form(n: Arc<Integer>, tx: mpsc::Sender<Fact>) {
     if n.is_zero() || n.as_ref().is_one() {
         return;
     }
     if let Some((x, y)) = power_form_impl(Arc::unwrap_or_clone(n)) {
-        tx.send(format!("This number is a perfect power: (#{x})(^(#{y}))."))
-            .await
-            .unwrap();
+        tx.send(Fact::Form(
+            "Perfect power form".to_owned(),
+            format!("(#{x})(^(#{y}))"),
+        ))
+        .await
+        .unwrap();
     }
 }
 

--- a/src/nerds/prime.rs
+++ b/src/nerds/prime.rs
@@ -3,11 +3,18 @@ use std::sync::Arc;
 use rug::{integer::IsPrime, Integer};
 use tokio::sync::mpsc;
 
-pub async fn prime(n: Arc<Integer>, tx: mpsc::Sender<String>) {
+use super::Fact;
+
+pub async fn prime(n: Arc<Integer>, tx: mpsc::Sender<Fact>) {
     match n.is_probably_prime(30) {
-        IsPrime::Yes => tx.send("Is a prime number.".to_string()).await.unwrap(),
+        IsPrime::Yes => tx
+            .send(Fact::Basic("Is a prime number.".to_string()))
+            .await
+            .unwrap(),
         IsPrime::Probably => tx
-            .send("Is almost certainly a prime number.".to_string())
+            .send(Fact::Basic(
+                "Is almost certainly a prime number.".to_string(),
+            ))
             .await
             .unwrap(),
         IsPrime::No => {}

--- a/src/nerds/triangular.rs
+++ b/src/nerds/triangular.rs
@@ -3,15 +3,19 @@ use std::sync::Arc;
 use rug::Integer;
 use tokio::sync::mpsc;
 
-pub async fn triangular(n: Arc<Integer>, tx: mpsc::Sender<String>) {
+use super::Fact;
+
+pub async fn triangular(n: Arc<Integer>, tx: mpsc::Sender<Fact>) {
     let (disc, rem) = (Arc::unwrap_or_clone(n) * 8_u8 + 1_u8).sqrt_rem(Integer::new());
     if !rem.is_zero() || disc.is_even() {
         return;
     }
     let root = (disc - 1) / 2;
-    tx.send(format!("Is the (#{root})th triangular number."))
-        .await
-        .unwrap();
+    tx.send(Fact::Basic(format!(
+        "Is the (#{root})th triangular number."
+    )))
+    .await
+    .unwrap();
 }
 
 #[cfg(test)]
@@ -32,7 +36,7 @@ mod tests {
             triangular(Arc::new(x), tx).await;
             prop_assert_eq!(
                 rx.recv().await,
-                Some(format!("Is the (#{nth})th triangular number."))
+                Some(Fact::Basic(format!("Is the (#{nth})th triangular number.")))
             );
         });
     }

--- a/templates/37.html
+++ b/templates/37.html
@@ -1,0 +1,4 @@
+<ul>
+    <li>37 is the median value for the second prime factor of an integer.</li>
+</ul>
+

--- a/templates/int.html
+++ b/templates/int.html
@@ -5,18 +5,38 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>NatWiki: {{ n }}</title>
+<style>
+td {
+    border: 1px solid black;
+    padding: 1em;
+}
+table {
+    border-collapse: collapse;
+}
+</style>
 </head>
 
 <body>
     <h1>{{ n }}</h1>
 
     <div class="manual">
-        {{ info.as_deref().unwrap_or("")|safe }}
+        {{ manual.as_deref().unwrap_or("")|safe }}
+    </div>
+
+    <div class="forms">
+        <h3>Alternative forms</h3>
+        <table>
+            <tbody>
+                {% for form in info.forms %}
+                <tr><td>{{ form.0 }}</td><td>{{ form.1|mathfmt|safe }}</td></tr>
+                {% endfor %}
+            </tbody>
+        </table>
     </div>
 
     <div class="auto">
         <ul>
-            {% for fact in facts %}
+            {% for fact in info.facts %}
             <li>{{ fact|mathfmt|safe }}</li>
             {% endfor %}
         </ul>


### PR DESCRIPTION
Add different types of facts. Currently supported are `Fact::Basic` representing a basic bullet-point fact and `Fact::Form` representing an alternative way of writing the number. Form facts are put into a table, whereas Basic facts are kept in the bullet-point format.